### PR TITLE
Update to Typst 0.12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM rust:slim-bullseye AS Builder
-ARG TYPST_VERSION=v0.11.1
+ARG TYPST_VERSION=v0.12.0
 
 
 RUN apt-get --allow-unauthenticated update && \


### PR DESCRIPTION
Typst v0.12.0 was recently released : https://github.com/typst/typst/releases/tag/v0.12.0
This PR upgrades the docker image to it.